### PR TITLE
Add a VDC parameter and fix networking issue

### DIFF
--- a/manager_blueprint/inputs.json.example
+++ b/manager_blueprint/inputs.json.example
@@ -4,6 +4,7 @@
     "vcloud_url": "",
     "vcloud_service": "",
     "vcloud_org": "",
+    "vcloud_vdc": "",
     "manager_server_name": "",
     "manager_server_catalog": "",
     "manager_server_template": "",

--- a/manager_blueprint/vcloud.yaml
+++ b/manager_blueprint/vcloud.yaml
@@ -48,6 +48,9 @@ inputs:
     vcloud_org:
         type: string
 
+    vcloud_vdc:
+        type: string
+
     manager_server_name:
         type: string
 

--- a/network_plugin/__init__.py
+++ b/network_plugin/__init__.py
@@ -69,7 +69,7 @@ def collectAssignedIps(gateway):
 def get_vm_ip(vca_client, ctx, gateway):
     try:
         vappName = get_vapp_name(ctx.source.instance.runtime_properties)
-        vdc = vca_client.get_vdc(get_vcloud_config()['org'])
+        vdc = vca_client.get_vdc(get_vcloud_config()['vdc'])
         vapp = vca_client.get_vapp(vdc, vappName)
         if not vapp:
             raise cfy_exc.NonRecoverableError("Could not find vApp {0}".format(vappName))
@@ -135,7 +135,7 @@ def get_network_name(properties):
 
 
 def is_network_exists(vca_client, network_name):
-    return bool(vca_client.get_network(get_vcloud_config()['org'], network_name))
+    return bool(vca_client.get_network(get_vcloud_config()['vdc'], network_name))
 
 
 def is_network_routed(vca_client, network_name, gateway):
@@ -153,7 +153,7 @@ def get_network(vca_client, network_name):
     if not network_name:
         raise cfy_exc.NonRecoverableError(
             "Network name is empty".format(network_name))
-    network = vca_client.get_network(get_vcloud_config()['org'], network_name)
+    network = vca_client.get_network(get_vcloud_config()['vdc'], network_name)
     if not network:
         raise cfy_exc.NonRecoverableError(
             "Network {0} could not be found".format(network_name))
@@ -168,7 +168,7 @@ def get_ondemand_public_ip(vca_client, gateway, ctx):
     else:
         raise cfy_exc.NonRecoverableError("Can't get public ip for ondemand service")
     # update gateway for new IP address
-    gateway = vca_client.get_gateways(get_vcloud_config()['org'])[0]
+    gateway = vca_client.get_gateways(get_vcloud_config()['vdc'])[0]
     new_public_ips = set(gateway.get_public_ips())
     new_ip = new_public_ips - old_public_ips
     if new_ip:
@@ -198,7 +198,7 @@ def get_public_ip(vca_client, gateway, service_type, ctx):
 
 
 def get_gateway(vca_client, gateway_name):
-    gateway = vca_client.get_gateway(get_vcloud_config()['org'],
+    gateway = vca_client.get_gateway(get_vcloud_config()['vdc'],
                                      gateway_name)
     if not gateway:
         raise cfy_exc.NonRecoverableError("Gateway {0}  not found".format(gateway_name))

--- a/network_plugin/network.py
+++ b/network_plugin/network.py
@@ -30,7 +30,7 @@ DELETE_POOL = 2
 @operation
 @with_vca_client
 def create(vca_client, **kwargs):
-    org_name = get_vcloud_config()['org']
+    vdc_name = get_vcloud_config()['vdc']
     if ctx.node.properties['use_external_resource']:
         network_name = ctx.node.properties['resource_id']
         if not is_network_exists(vca_client, network_name):
@@ -40,12 +40,12 @@ def create(vca_client, **kwargs):
         return
     net_prop = ctx.node.properties["network"]
     network_name = get_network_name(ctx.node.properties)
-    if network_name in _get_network_list(vca_client, get_vcloud_config()['org']):
+    if network_name in _get_network_list(vca_client, get_vcloud_config()['vdc']):
         raise cfy_exc.NonRecoverableError("Network {0} already exists, but parameter 'use_external_resource' is 'false' or absent".format(network_name))
 
     ip = _split_adresses(net_prop['static_range'])
     gateway_name = net_prop['edge_gateway']
-    if not vca_client.get_gateway(org_name, gateway_name):
+    if not vca_client.get_gateway(vdc_name, gateway_name):
         raise cfy_exc.NonRecoverableError("Gateway {0} not found".format(gateway_name))
     start_address = check_ip(ip.start)
     end_address = check_ip(ip.end)
@@ -54,7 +54,7 @@ def create(vca_client, **kwargs):
     dns1 = check_ip(net_prop["dns"]) if net_prop.get('dns') else ""
     dns2 = ""
     dns_suffix = net_prop.get("dns_suffix")
-    success, result = vca_client.create_vdc_network(org_name, network_name, gateway_name, start_address,
+    success, result = vca_client.create_vdc_network(vdc_name, network_name, gateway_name, start_address,
                                                     end_address, gateway_ip, netmask,
                                                     dns1, dns2, dns_suffix)
     if success:
@@ -78,7 +78,7 @@ def delete(vca_client, **kwargs):
         return
     network_name = get_network_name(ctx.node.properties)
     _dhcp_operation(vca_client, network_name, DELETE_POOL)
-    success, task = vca_client.delete_vdc_network(get_vcloud_config()['org'], network_name)
+    success, task = vca_client.delete_vdc_network(get_vcloud_config()['vdc'], network_name)
     if success:
         ctx.logger.info("Network {0} has been successful deleted.".format(network_name))
     else:
@@ -101,7 +101,7 @@ def creation_validation(vca_client, **kwargs):
 
     net_prop = get_mandatory(ctx.node.properties, "network")
     gateway_name = get_mandatory(net_prop, 'edge_gateway')
-    if not vca_client.get_gateway(get_vcloud_config()['org'], gateway_name):
+    if not vca_client.get_gateway(get_vcloud_config()['vdc'], gateway_name):
         raise cfy_exc.NonRecoverableError("Gateway {0} not found".format(gateway_name))
 
     static_ip = _split_adresses(get_mandatory(net_prop, 'static_range'))
@@ -130,7 +130,7 @@ def _dhcp_operation(vca_client, network_name, operation):
     if dhcp_settings is None:
         return
     gateway_name = ctx.node.properties["network"]['edge_gateway']
-    gateway = vca_client.get_gateway(get_vcloud_config()['org'], gateway_name)
+    gateway = vca_client.get_gateway(get_vcloud_config()['vdc'], gateway_name)
     if not gateway:
         raise cfy_exc.NonRecoverableError("Gateway {0} not found!".format(gateway_name))
 
@@ -171,9 +171,9 @@ def _split_adresses(address_range):
             "Incorrect Ip addresses: {0}".format(address_range))
 
 
-def _get_network_list(vca_client, org_name):
-    vdc = vca_client.get_vdc(org_name)
+def _get_network_list(vca_client, vdc_name):
+    vdc = vca_client.get_vdc(vdc_name)
     if not vdc:
         raise cfy_exc.NonRecoverableError(
-            "Vdc {0} not found.".format(org_name))
+            "Vdc {0} not found.".format(vdc_name))
     return [net.name for net in vdc.AvailableNetworks.Network]

--- a/server_plugin/server.py
+++ b/server_plugin/server.py
@@ -83,7 +83,7 @@ def create(vca_client, **kwargs):
         memory = hardware.get('memory')
         _check_hardware(cpu, memory)
     ctx.logger.info("Creating VApp with parameters: {0}".format(str(server)))
-    task = vca_client.create_vapp(config['org'],
+    task = vca_client.create_vapp(config['vdc'],
                                   vapp_name,
                                   vapp_template,
                                   vapp_catalog,
@@ -101,7 +101,7 @@ def create(vca_client, **kwargs):
 
     if connections:
         for index, connection in enumerate(connections):
-            vdc = vca_client.get_vdc(config['org'])
+            vdc = vca_client.get_vdc(config['vdc'])
             vapp = vca_client.get_vapp(vdc, vapp_name)
             if vapp is None:
                 raise cfy_exc.NonRecoverableError(
@@ -143,7 +143,7 @@ def create(vca_client, **kwargs):
 
     custom = server.get(GUEST_CUSTOMIZATION)
     if custom:
-        vdc = vca_client.get_vdc(config['org'])
+        vdc = vca_client.get_vdc(config['vdc'])
         vapp = vca_client.get_vapp(vdc, vapp_name)
         script = _build_script(custom)
         password = custom.get('admin_password')
@@ -172,7 +172,7 @@ def create(vca_client, **kwargs):
 def start(vca_client, **kwargs):
     vapp_name = get_vapp_name(ctx.instance.runtime_properties)
     config = get_vcloud_config()
-    vdc = vca_client.get_vdc(config['org'])
+    vdc = vca_client.get_vdc(config['vdc'])
     vapp = vca_client.get_vapp(vdc, vapp_name)
     if _vapp_is_on(vapp) is False:
         ctx.logger.info("Power-on VApp {0}".format(vapp_name))
@@ -192,7 +192,7 @@ def start(vca_client, **kwargs):
 def stop(vca_client, **kwargs):
     vapp_name = get_vapp_name(ctx.instance.runtime_properties)
     config = get_vcloud_config()
-    vdc = vca_client.get_vdc(config['org'])
+    vdc = vca_client.get_vdc(config['vdc'])
     vapp = vca_client.get_vapp(vdc, vapp_name)
     ctx.logger.info("Power-off and undeploy VApp {0}".format(vapp_name))
     task = vapp.undeploy()
@@ -206,7 +206,7 @@ def stop(vca_client, **kwargs):
 def delete(vca_client, **kwargs):
     vapp_name = get_vapp_name(ctx.instance.runtime_properties)
     config = get_vcloud_config()
-    vdc = vca_client.get_vdc(config['org'])
+    vdc = vca_client.get_vdc(config['vdc'])
     vapp = vca_client.get_vapp(vdc, vapp_name)
     ctx.logger.info("Deleting VApp {0}".format(vapp_name))
     task = vapp.delete()
@@ -219,7 +219,7 @@ def delete(vca_client, **kwargs):
 def _get_state(vca_client, ctx):
     vapp_name = get_vapp_name(ctx.instance.runtime_properties)
     config = get_vcloud_config()
-    vdc = vca_client.get_vdc(config['org'])
+    vdc = vca_client.get_vdc(config['vdc'])
     vapp = vca_client.get_vapp(vdc, vapp_name)
     nw_connections = _get_vm_network_connections(vapp)
     if len(nw_connections) == 0:
@@ -379,9 +379,13 @@ def _create_connection(network, ip_address, mac_address, ip_allocation_mode,
 
 
 def _isDhcpAvailable(vca_client, network_name):
-    org_name = get_vcloud_config()['org']
-    admin_href = vca_client.get_admin_network_href(org_name, network_name)
-    for gate in vca_client.get_gateways(org_name):
+    vdc_name = get_vcloud_config()['vdc']
+    network = vca_client.get_network(vdc_name, network_name)
+    if network.get_Configuration().get_FenceMode() == "bridged":
+        return True         # Can't tell whether bridged networks have DHCP so just hope for the best
+    # TODO: Why not just get the gateway directly from the network?
+    admin_href = vca_client.get_admin_network_href(vdc_name, network_name)
+    for gate in vca_client.get_gateways(vdc_name):
         for pool in gate.get_dhcp_pools():
             if admin_href == pool.get_Network().get_href():
                 return True


### PR DESCRIPTION
The original code was written apparently assuming that Orgs and VDCs are one-to-one and have the same name. While this is true in the vCA Subscription stack, it's not true in either the vCA OnDemand stack or in standalone vCD. This change adds a VDC parameter to address this limitation.

Also, the original code was written assuming that VDC networks are always connected to gateways. However, only _routed_ VDC networks can be connected to gateways. _Bridged_ VDC networks can not. Although vCA doesn't support bridged VDC networks, standalone vCD environments often do. This change addresses the bridged VDC network scenario.
