### PR TITLE
Add an explicit requirement on PyYAML

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'cloudify-plugins-common>=3.2',
         'pyvcloud==12',
         'requests==2.4.3',
-        'IPy==0.81'
+        'IPy==0.81',
+        'PyYAML==3.10'
     ]
 )


### PR DESCRIPTION
Instead of relying the fact that pyvcloud pulls it in (but won't in future versions, since it doesn't need it).
